### PR TITLE
Allow for skipping updates to a sorting attribute

### DIFF
--- a/app/controllers/sortable_tree_controller.rb
+++ b/app/controllers/sortable_tree_controller.rb
@@ -15,9 +15,8 @@ module SortableTreeController
           resource_class = class_name.to_s.camelize.constantize
 
           # options
-          options[:tree] = true
-          options[:sorting_attribute] ||= 'pos'
-          options[:parent_method] ||= 'parent'
+          sorting_attribute = options.fetch(:sorting_attribute, 'pos')
+          parent_method = options[:parent_method] || 'parent'
 
           records = params[:cat].to_unsafe_h.inject({}) do |res, (resource, parent_resource)|
             res[resource_class.find(resource)] = resource_class.find(parent_resource) rescue nil
@@ -27,10 +26,12 @@ module SortableTreeController
           errors = []
           ActiveRecord::Base.transaction do
             records.each_with_index do |(record, parent_record), position|
-              record.send "#{options[:sorting_attribute]}=", position
-              if options[:tree]
-                record.send "#{options[:parent_method]}=", parent_record
+              if sorting_attribute
+                record.send "#{sorting_attribute}=", position
               end
+
+              record.send "#{parent_method}=", parent_record
+
               errors << {record.id => record.errors} if !record.save
             end
           end

--- a/readme.md
+++ b/readme.md
@@ -153,7 +153,7 @@ in controller:
 
 
 * ClassName - class name (camel case). For example, 'Category'.
-* :sorting_attribute - attribute used for sorting (default: 'pos')
+* :sorting_attribute - attribute used for sorting, set to `nil` to skip updates to a position attribute (default: 'pos')
 * :parent_method - method used to access parent for the item (default: 'parent')
 
 


### PR DESCRIPTION
Fixes #9.

By setting the `sorting_attribute` to `nil` updates to the (missing) sorting column are avoided.

Note that this introduces a small incompatibility with previous versions if a user already specifies `sorting_attribute: nil`, but depends on its default value of 'pos'. That wouldn't be very idiomatic, so the incompatibility may be acceptable.

Comes with a small refactoring that removes code for the undocumented and unconfigurable `:tree` option.