### PR TITLE
uuid support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -230,7 +230,18 @@ If you use ancestry in model - set :parent_method to 'parent'.
 
 * edit file 'views/sortable/_sortable.html.haml' to access the whole layout
 
+# UUID support
 
+When using uuid instead of id, add this to `application.js`:
+```javascript
+$(document).ready(function() {
+  $('.sortable_tree').each(function () {
+    $(this).nestedSortable({
+      expression: /(.+)_(.+)/,
+    });
+  });
+});
+```
 
 
 


### PR DESCRIPTION
I had some sortable issues when using uuid instead of id. Sortable can handle uuid when the expression is changed. 

Thanks to: [https://forum.jquery.com/topic/sortable-issue-when-using-a-uuid-as-primary-key](https://forum.jquery.com/topic/sortable-issue-when-using-a-uuid-as-primary-key)